### PR TITLE
Include vendor scripts

### DIFF
--- a/generators/app/templates/_.angular-cli.json
+++ b/generators/app/templates/_.angular-cli.json
@@ -23,7 +23,11 @@
       "styles": [
         "main.scss"
       ],
-      "scripts": [],
+      "scripts": [
+        "../node_modules/jquery/dist/jquery.js",
+        "../node_modules/tether/dist/js/tether.js",
+        "../node_modules/bootstrap/dist/js/bootstrap.js"
+      ],
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",


### PR DESCRIPTION
Include jQuery, Tether, and Bootstrap scripts.

Without these scripts the `.navbar-toggler` does not work when the navigation is collapsed. Would also assume that none of the other Bootstrap JavaScript components would work either.